### PR TITLE
add verify and generate token emulator support

### DIFF
--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -34,7 +34,6 @@ VALID_EMAIL_ACTION_TYPES = set(['VERIFY_EMAIL', 'EMAIL_SIGNIN', 'PASSWORD_RESET'
 
 _EMULATOR_HOST_ENV_VAR = 'FIREBASE_AUTH_EMULATOR_HOST'
 
-
 def validate_uid(uid, required=False):
     if uid is None and not required:
         return None
@@ -339,19 +338,19 @@ def is_emulator_enabled():
     return bool(emulator_host())
 
 
-def get_token_cert_url(version='v1'):
-    path = '/robot/{0}/metadata/x509/securetoken@system.gserviceaccount.com'.format(version)
-    protocol = emulator_host() if is_emulator_enabled() else 'https://'
-    return '{0}www.googleapis.com{1}'.format(protocol, path)
-
-
 def get_cookie_cert_url(version='v3'):
     path = '/identitytoolkit/{0}/relyingparty/publicKeys'.format(version)
     protocol = emulator_host() if is_emulator_enabled() else 'https://'
     return '{0}www.googleapis.com{1}'.format(protocol, path)
 
 
-def get_auth_resource_url(project_id, version='v1', tenant_id=None):
+def get_id_token_cert_url(version='v1'):
+    path = '/robot/{0}/metadata/x509/securetoken@system.gserviceaccount.com'.format(version)
+    protocol = emulator_host() if is_emulator_enabled() else 'https://'
+    return '{0}www.googleapis.com{1}'.format(protocol, path)
+
+
+def get_auth_resource_url(project_id, tenant_id=None, version='v1'):
     path = ('/{0}/projects/{1}'.format(version, project_id) if tenant_id is None else
             '/{0}/projects/{1}/tenants/{2}'.format(version, project_id, tenant_id))
     protocol = emulator_host() if is_emulator_enabled() else 'https://'

--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -14,7 +14,6 @@
 
 """Firebase auth utils."""
 
-import collections
 import json
 import os
 import re

--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -14,6 +14,7 @@
 
 """Firebase auth utils."""
 
+import collections
 import json
 import os
 import re
@@ -31,10 +32,6 @@ RESERVED_CLAIMS = set([
     'iss', 'jti', 'nbf', 'nonce', 'sub', 'firebase',
 ])
 VALID_EMAIL_ACTION_TYPES = set(['VERIFY_EMAIL', 'EMAIL_SIGNIN', 'PASSWORD_RESET'])
-
-# The Firebase Auth backend base URL format.
-FIREBASE_AUTH_BASE_URL_FORMAT = (
-    'identitytoolkit.googleapis.com/{version}/projects/{project_id}{api}')
 
 
 def validate_uid(uid, required=False):
@@ -338,31 +335,8 @@ def is_emulator_enabled():
     return bool(emulator_host())
 
 
-class AuthResourceUrlBuilder(object):
-    """Utility class to help building resource URLs."""
-
-    def __init__(self, project_id, version='v1'):
-        """The resource URL builder constructor.
-
-        Args:
-            project_id: The resource project ID.
-            version: The endpoint API version.
-        """
-        self.project_id = project_id
-        self.version = version
-        self._url_format = '{0}{1}'.format(
-            'http://{0}/'.format(emulator_host()) if is_emulator_enabled() else 'https://',
-            FIREBASE_AUTH_BASE_URL_FORMAT)
-
-    def get_url(self, api='', **params):
-        """Returns the resource URL corresponding to the provided parameters.
-
-        Args:
-            api: The backend API name (optional).
-            **params: The optional additional parameters to substitute in the URL path.
-
-        Returns:
-            string: The corresponding resource URL.
-        """
-        return self._url_format.format(
-            api=api, project_id=self.project_id, version=self.version, **params)
+def get_auth_resource_url(project_id, version='v1', api='', tenant_id=None):
+    path = ('/{0}/projects/{1}'.format(version, project_id) if tenant_id is None else
+            '/{0}/projects/{1}/tenants/{2}'.format(version, project_id, tenant_id))
+    protocol = 'http://{0}/'.format(emulator_host()) if is_emulator_enabled() else 'https://'
+    return '{0}identitytoolkit.googleapis.com{1}{2}'.format(protocol, path, api)

--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -339,14 +339,14 @@ def is_emulator_enabled():
     return bool(emulator_host())
 
 
-def get_cookie_cert_url(version='v3'):
-    path = '/identitytoolkit/{0}/relyingparty'.format(version)
+def get_token_cert_url(version='v1'):
+    path = '/robot/{0}/metadata/x509/securetoken@system.gserviceaccount.com'.format(version)
     protocol = emulator_host() if is_emulator_enabled() else 'https://'
     return '{0}www.googleapis.com{1}'.format(protocol, path)
 
 
-def get_token_cert_url(version='v1'):
-    path = '/robot/{0}/metadata/x509/securetoken@system.gserviceaccount.com'.format(version)
+def get_cookie_cert_url(version='v3'):
+    path = '/identitytoolkit/{0}/relyingparty/publicKeys'.format(version)
     protocol = emulator_host() if is_emulator_enabled() else 'https://'
     return '{0}www.googleapis.com{1}'.format(protocol, path)
 

--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -334,20 +334,32 @@ def is_emulator_enabled():
     return bool(emulator_host())
 
 
-def get_cookie_cert_url(api='', version='v3'):
+def get_cookie_cert_url(version='v3'):
     path = '/identitytoolkit/{0}/relyingparty'.format(version)
     protocol = 'http://{0}/'.format(emulator_host()) if is_emulator_enabled() else 'https://'
-    return '{0}www.googleapis.com{1}{2}'.format(protocol, path, api)
+    return '{0}www.googleapis.com{1}'.format(protocol, path)
 
 
-def get_token_issuer(api='', version='v1'):
-    path = '/{0}/token'.format(version)
+def get_token_cert_url(version='v1'):
+    path = '/robot/{0}/metadata/x509/securetoken@system.gserviceaccount.com'.format(version)
     protocol = 'http://{0}/'.format(emulator_host()) if is_emulator_enabled() else 'https://'
-    return '{0}securetoken.googleapis.com{1}{2}'.format(protocol, path, api)
+    return '{0}www.googleapis.com{1}'.format(protocol, path)
 
 
-def get_auth_resource_url(project_id, version='v1', api='', tenant_id=None):
+def get_cookie_issuer():
+    path = '/'
+    protocol = 'http://{0}/'.format(emulator_host()) if is_emulator_enabled() else 'https://'
+    return '{0}session.firebase.google.com{1}'.format(protocol, path)
+
+
+def get_token_issuer():
+    path = '/'
+    protocol = 'http://{0}/'.format(emulator_host()) if is_emulator_enabled() else 'https://'
+    return '{0}securetoken.google.com{1}'.format(protocol, path)
+
+
+def get_auth_resource_url(project_id, version='v1', tenant_id=None):
     path = ('/{0}/projects/{1}'.format(version, project_id) if tenant_id is None else
             '/{0}/projects/{1}/tenants/{2}'.format(version, project_id, tenant_id))
     protocol = 'http://{0}/'.format(emulator_host()) if is_emulator_enabled() else 'https://'
-    return '{0}identitytoolkit.googleapis.com{1}{2}'.format(protocol, path, api)
+    return '{0}identitytoolkit.googleapis.com{1}'.format(protocol, path)

--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -34,19 +34,7 @@ VALID_EMAIL_ACTION_TYPES = set(['VERIFY_EMAIL', 'EMAIL_SIGNIN', 'PASSWORD_RESET'
 
 # The Firebase Auth backend base URL format.
 FIREBASE_AUTH_BASE_URL_FORMAT = (
-    'https://identitytoolkit.googleapis.com/{version}/projects/{project_id}{api}')
-
-# Firebase Auth base URL format when using the auth emultor.
-FIREBASE_AUTH_EMULATOR_BASE_URL_FORMAT = (
-    'http://{host}/identitytoolkit.googleapis.com/{version}/projects/{project_id}{api}')
-
-# The Firebase Auth backend multi-tenancy base URL format.
-FIREBASE_AUTH_TENANT_URL_FORMAT = FIREBASE_AUTH_BASE_URL_FORMAT.replace(
-    'projects/{project_id}', 'projects/{project_id}/tenants/{tenant_id}')
-
-# Firebase Auth base URL format when using the auth emultor with multi-tenancy.
-FIREBASE_AUTH_EMULATOR_TENANT_URL_FORMAT = FIREBASE_AUTH_EMULATOR_BASE_URL_FORMAT.replace(
-    'projects/{project_id}', 'projects/{project_id}/tenants/{tenant_id}')
+    'identitytoolkit.googleapis.com/{version}/projects/{project_id}{api}')
 
 
 def validate_uid(uid, required=False):
@@ -362,9 +350,9 @@ class AuthResourceUrlBuilder(object):
         """
         self.project_id = project_id
         self.version = version
-        self._url_format = (
-            FIREBASE_AUTH_EMULATOR_BASE_URL_FORMAT.format(host=emulator_host())
-            if is_emulator_enabled() else FIREBASE_AUTH_BASE_URL_FORMAT)
+        self._url_format = '{0}{1}'.format(
+            'http://{0}/'.format(emulator_host()) if is_emulator_enabled() else 'https://',
+            FIREBASE_AUTH_BASE_URL_FORMAT)
 
     def get_url(self, api='', **params):
         """Returns the resource URL corresponding to the provided parameters.
@@ -378,34 +366,3 @@ class AuthResourceUrlBuilder(object):
         """
         return self._url_format.format(
             api=api, project_id=self.project_id, version=self.version, **params)
-
-
-class TenantAwareAuthResourceUrlBuilder(AuthResourceUrlBuilder):
-    """Tenant aware resource builder utility."""
-
-    def __init__(self, project_id, version, tenant_id):
-        """The tenant aware resource URL builder constructor.
-
-        Args:
-            project_id: The resource project ID.
-            version: The endpoint API version.
-            tenant_id: The tenant ID.
-        """
-        super(TenantAwareAuthResourceUrlBuilder, self).__init__(project_id, version)
-        self.tenant_id = tenant_id
-        self._url_format = (
-            FIREBASE_AUTH_EMULATOR_TENANT_URL_FORMAT.format(host=emulator_host())
-            if is_emulator_enabled() else FIREBASE_AUTH_TENANT_URL_FORMAT)
-
-    def get_url(self, api='', **params):
-        """Returns the resource URL corresponding to the provided parameters.
-
-        Args:
-            api: The backend API name (optional).
-            **params: The optional additional parameters to substitute in the URL path.
-
-        Returns:
-            string: The corresponding resource URL.
-        """
-        return super(TenantAwareAuthResourceUrlBuilder, self).get_url(
-            api=api, tenant_id=self.tenant_id, **params)

--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -334,6 +334,18 @@ def is_emulator_enabled():
     return bool(emulator_host())
 
 
+def get_cookie_cert_url(api='', version='v3'):
+    path = '/identitytoolkit/{0}/relyingparty'.format(version)
+    protocol = 'http://{0}/'.format(emulator_host()) if is_emulator_enabled() else 'https://'
+    return '{0}www.googleapis.com{1}{2}'.format(protocol, path, api)
+
+
+def get_token_issuer(api='', version='v1'):
+    path = '/{0}/token'.format(version)
+    protocol = 'http://{0}/'.format(emulator_host()) if is_emulator_enabled() else 'https://'
+    return '{0}securetoken.googleapis.com{1}{2}'.format(protocol, path, api)
+
+
 def get_auth_resource_url(project_id, version='v1', api='', tenant_id=None):
     path = ('/{0}/projects/{1}'.format(version, project_id) if tenant_id is None else
             '/{0}/projects/{1}/tenants/{2}'.format(version, project_id, tenant_id))

--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -32,6 +32,8 @@ RESERVED_CLAIMS = set([
 ])
 VALID_EMAIL_ACTION_TYPES = set(['VERIFY_EMAIL', 'EMAIL_SIGNIN', 'PASSWORD_RESET'])
 
+_EMULATOR_HOST_ENV_VAR = 'FIREBASE_AUTH_EMULATOR_HOST'
+
 
 def validate_uid(uid, required=False):
     if uid is None and not required:
@@ -327,7 +329,10 @@ def _build_error_message(code, exc_type, custom_message):
 
 
 def emulator_host():
-    return os.environ.get('FIREBASE_AUTH_EMULATOR_HOST')
+    env_val = os.environ.get(_EMULATOR_HOST_ENV_VAR)
+    if env_val and '//' not in env_val:
+        return 'http://{0}/'.format(env_val)
+    return None
 
 
 def is_emulator_enabled():
@@ -336,30 +341,18 @@ def is_emulator_enabled():
 
 def get_cookie_cert_url(version='v3'):
     path = '/identitytoolkit/{0}/relyingparty'.format(version)
-    protocol = 'http://{0}/'.format(emulator_host()) if is_emulator_enabled() else 'https://'
+    protocol = emulator_host() if is_emulator_enabled() else 'https://'
     return '{0}www.googleapis.com{1}'.format(protocol, path)
 
 
 def get_token_cert_url(version='v1'):
     path = '/robot/{0}/metadata/x509/securetoken@system.gserviceaccount.com'.format(version)
-    protocol = 'http://{0}/'.format(emulator_host()) if is_emulator_enabled() else 'https://'
+    protocol = emulator_host() if is_emulator_enabled() else 'https://'
     return '{0}www.googleapis.com{1}'.format(protocol, path)
-
-
-def get_cookie_issuer():
-    path = '/'
-    protocol = 'http://{0}/'.format(emulator_host()) if is_emulator_enabled() else 'https://'
-    return '{0}session.firebase.google.com{1}'.format(protocol, path)
-
-
-def get_token_issuer():
-    path = '/'
-    protocol = 'http://{0}/'.format(emulator_host()) if is_emulator_enabled() else 'https://'
-    return '{0}securetoken.google.com{1}'.format(protocol, path)
 
 
 def get_auth_resource_url(project_id, version='v1', tenant_id=None):
     path = ('/{0}/projects/{1}'.format(version, project_id) if tenant_id is None else
             '/{0}/projects/{1}/tenants/{2}'.format(version, project_id, tenant_id))
-    protocol = 'http://{0}/'.format(emulator_host()) if is_emulator_enabled() else 'https://'
+    protocol = emulator_host() if is_emulator_enabled() else 'https://'
     return '{0}identitytoolkit.googleapis.com{1}'.format(protocol, path)

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -34,7 +34,11 @@ from firebase_admin import exceptions
 from firebase_admin import _auth_utils
 
 
+# ID token constants
+ID_TOKEN_ISSUER_PREFIX = 'https://securetoken.google.com/'
+
 # Session cookie constants
+COOKIE_ISSUER_PREFIX = 'https://session.firebase.google.com/'
 MIN_SESSION_COOKIE_DURATION_SECONDS = int(datetime.timedelta(minutes=5).total_seconds())
 MAX_SESSION_COOKIE_DURATION_SECONDS = int(datetime.timedelta(days=14).total_seconds())
 
@@ -232,7 +236,7 @@ class TokenVerifier(object):
             operation='verify_id_token()',
             doc_url='https://firebase.google.com/docs/auth/admin/verify-id-tokens',
             cert_url=_auth_utils.get_token_cert_url(),
-            issuer=_auth_utils.get_token_issuer(),
+            issuer=ID_TOKEN_ISSUER_PREFIX,
             invalid_token_error=_auth_utils.InvalidIdTokenError,
             expired_token_error=ExpiredIdTokenError)
         self.cookie_verifier = _JWTVerifier(
@@ -240,7 +244,7 @@ class TokenVerifier(object):
             operation='verify_session_cookie()',
             doc_url='https://firebase.google.com/docs/auth/admin/verify-id-tokens',
             cert_url=_auth_utils.get_cookie_cert_url('/relyingparty'),
-            issuer=_auth_utils.get_cookie_issuer(),
+            issuer=COOKIE_ISSUER_PREFIX,
             invalid_token_error=InvalidSessionCookieError,
             expired_token_error=ExpiredSessionCookieError)
 

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -394,12 +394,14 @@ class _JWTVerifier(object):
         self._verify_iss(payload)
         self._verify_sub(payload)
 
-        if not _auth_utils.is_emulator_enabled():
+        if _auth_utils.is_emulator_enabled():
+            # NOTE: `_verify_token_signature` handles `iat` and `exp` verification as a byproduct,
+            # but we do not want to check signatures while running in emulator-mode so we explicitly
+            # check `iat` and `exp` ourselves instead.
+            self._verify_iat_and_exp(payload)
+        else:
             self._verify_kid_and_alg(header, payload)
             self._verify_token_signature(token, request)
-        else:
-            # Normally, _verify_token_signature handles "iat" and "exp" verification.
-            self._verify_iat_and_exp(payload)
 
         payload['uid'] = payload['sub']
         return payload

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -60,7 +60,7 @@ class _EmulatedSigner(crypt.Signer):
 
     @property
     def key_id(self):
-        return b''
+        return None
 
     def sign(self, unused_message):
         return b''
@@ -90,10 +90,6 @@ class _SigningProvider(object):
         signer = iam.Signer(request, google_cred, service_account)
         return _SigningProvider(signer, service_account)
 
-    @classmethod
-    def emulated(cls):
-        return _SigningProvider(_EmulatedSigner(), 'firebase-auth-emulator@example.com')
-
 
 class TokenGenerator(object):
     """Generates custom tokens and session cookies."""
@@ -107,7 +103,7 @@ class TokenGenerator(object):
     def _init_signing_provider(self):
         """Initializes a signing provider by following the go/firebase-admin-sign protocol."""
         if _auth_utils.is_emulator_enabled():
-            return _SigningProvider.emulated()
+            return _SigningProvider(_EmulatedSigner(), 'firebase-auth-emulator@example.com')
 
         # If the SDK was initialized with a service account, use it to sign bytes.
         google_cred = self.app.credential.get_credential()
@@ -235,7 +231,7 @@ class TokenVerifier(object):
             project_id=app.project_id, short_name='ID token',
             operation='verify_id_token()',
             doc_url='https://firebase.google.com/docs/auth/admin/verify-id-tokens',
-            cert_url=_auth_utils.get_token_cert_url(),
+            cert_url=_auth_utils.get_id_token_cert_url(),
             issuer=ID_TOKEN_ISSUER_PREFIX,
             invalid_token_error=_auth_utils.InvalidIdTokenError,
             expired_token_error=ExpiredIdTokenError)

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -343,7 +343,7 @@ class _JWTVerifier(object):
         key_id = header.get('kid')
         algorithm = header.get('alg')
         if not key_id:
-            if algorithm == 'HS256' and payload.get('v') is 0 and 'uid' in payload.get('d', {}):
+            if algorithm == 'HS256' and payload.get('v') == 0 and 'uid' in payload.get('d', {}):
                 raise self._invalid_token_error(
                     '{0} expects {1}, but was given a legacy custom '
                     'token.'.format(self.operation, self.articled_short_name))

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -14,6 +14,7 @@
 
 """Firebase token minting and validation sub module."""
 
+import calendar
 import datetime
 import time
 
@@ -21,6 +22,7 @@ import cachecontrol
 import requests
 import six
 from google.auth import credentials
+from google.auth import crypt
 from google.auth import iam
 from google.auth import jwt
 from google.auth import transport
@@ -54,6 +56,18 @@ RESERVED_CLAIMS = set([
 METADATA_SERVICE_URL = ('http://metadata.google.internal/computeMetadata/v1/instance/'
                         'service-accounts/default/email')
 
+_CLOCK_SKEW_SECS = 10  # 10 seconds
+
+
+class _EmulatedSigner(crypt.Signer):
+
+    @property
+    def key_id(self):
+        return None
+
+    def sign(self, unused_message):
+        return b''
+
 
 class _SigningProvider(object):
     """Stores a reference to a google.auth.crypto.Signer."""
@@ -79,6 +93,10 @@ class _SigningProvider(object):
         signer = iam.Signer(request, google_cred, service_account)
         return _SigningProvider(signer, service_account)
 
+    @classmethod
+    def emulated(cls):
+        return _SigningProvider(_EmulatedSigner(), 'firebase-auth-emulator@example.com')
+
 
 class TokenGenerator(object):
     """Generates custom tokens and session cookies."""
@@ -91,6 +109,9 @@ class TokenGenerator(object):
 
     def _init_signing_provider(self):
         """Initializes a signing provider by following the go/firebase-admin-sign protocol."""
+        if _auth_utils.is_emulator_enabled():
+            return _SigningProvider.emulated()
+
         # If the SDK was initialized with a service account, use it to sign bytes.
         google_cred = self.app.credential.get_credential()
         if isinstance(google_cred, google.oauth2.service_account.Credentials):
@@ -254,6 +275,19 @@ class _JWTVerifier(object):
         self._invalid_token_error = kwargs.pop('invalid_token_error')
         self._expired_token_error = kwargs.pop('expired_token_error')
 
+    @property
+    def verify_id_token_msg(self):
+        return 'See {0} for details on how to retrieve {1}.'.format(self.url, self.short_name)
+
+    @property
+    def project_id_match_msg(self):
+        return ('Make sure the {0} comes from the same Firebase project as the service account '
+                'used to authenticate this SDK.'.format(self.short_name))
+
+    @property
+    def expected_issuer(self):
+        return self.issuer + self.project_id
+
     def verify(self, token, request):
         """Verifies the signature and data for the provided JWT."""
         token = token.encode('utf-8') if isinstance(token, six.text_type) else token
@@ -270,74 +304,19 @@ class _JWTVerifier(object):
                 'GOOGLE_CLOUD_PROJECT environment variable.'.format(self.operation))
 
         header, payload = self._decode_unverified(token)
-        issuer = payload.get('iss')
-        audience = payload.get('aud')
-        subject = payload.get('sub')
-        expected_issuer = self.issuer + self.project_id
 
-        project_id_match_msg = (
-            'Make sure the {0} comes from the same Firebase project as the service account used '
-            'to authenticate this SDK.'.format(self.short_name))
-        verify_id_token_msg = (
-            'See {0} for details on how to retrieve {1}.'.format(self.url, self.short_name))
+        self._verify_aud(payload)
+        if not _auth_utils.is_emulator_enabled():
+            self._verify_kid_and_alg(header, payload)
+        self._verify_iss(payload)
+        self._verify_sub(payload)
+        if not _auth_utils.is_emulator_enabled():
+            self._verify_token_signature(token, request)
+        else:
+            self._verify_iat_and_exp(payload)
 
-        error_message = None
-        if audience == FIREBASE_AUDIENCE:
-            error_message = (
-                '{0} expects {1}, but was given a custom '
-                'token.'.format(self.operation, self.articled_short_name))
-        elif not header.get('kid'):
-            if header.get('alg') == 'HS256' and payload.get(
-                    'v') is 0 and 'uid' in payload.get('d', {}):
-                error_message = (
-                    '{0} expects {1}, but was given a legacy custom '
-                    'token.'.format(self.operation, self.articled_short_name))
-            else:
-                error_message = 'Firebase {0} has no "kid" claim.'.format(self.short_name)
-        elif header.get('alg') != 'RS256':
-            error_message = (
-                'Firebase {0} has incorrect algorithm. Expected "RS256" but got '
-                '"{1}". {2}'.format(self.short_name, header.get('alg'), verify_id_token_msg))
-        elif audience != self.project_id:
-            error_message = (
-                'Firebase {0} has incorrect "aud" (audience) claim. Expected "{1}" but '
-                'got "{2}". {3} {4}'.format(self.short_name, self.project_id, audience,
-                                            project_id_match_msg, verify_id_token_msg))
-        elif issuer != expected_issuer:
-            error_message = (
-                'Firebase {0} has incorrect "iss" (issuer) claim. Expected "{1}" but '
-                'got "{2}". {3} {4}'.format(self.short_name, expected_issuer, issuer,
-                                            project_id_match_msg, verify_id_token_msg))
-        elif subject is None or not isinstance(subject, six.string_types):
-            error_message = (
-                'Firebase {0} has no "sub" (subject) claim. '
-                '{1}'.format(self.short_name, verify_id_token_msg))
-        elif not subject:
-            error_message = (
-                'Firebase {0} has an empty string "sub" (subject) claim. '
-                '{1}'.format(self.short_name, verify_id_token_msg))
-        elif len(subject) > 128:
-            error_message = (
-                'Firebase {0} has a "sub" (subject) claim longer than 128 characters. '
-                '{1}'.format(self.short_name, verify_id_token_msg))
-
-        if error_message:
-            raise self._invalid_token_error(error_message)
-
-        try:
-            verified_claims = google.oauth2.id_token.verify_token(
-                token,
-                request=request,
-                audience=self.project_id,
-                certs_url=self.cert_url)
-            verified_claims['uid'] = verified_claims['sub']
-            return verified_claims
-        except google.auth.exceptions.TransportError as error:
-            raise CertificateFetchError(str(error), cause=error)
-        except ValueError as error:
-            if 'Token expired' in str(error):
-                raise self._expired_token_error(str(error), cause=error)
-            raise self._invalid_token_error(str(error), cause=error)
+        payload['uid'] = payload['sub']
+        return payload
 
     def _decode_unverified(self, token):
         try:
@@ -346,6 +325,82 @@ class _JWTVerifier(object):
             return header, payload
         except ValueError as error:
             raise self._invalid_token_error(str(error), cause=error)
+
+    def _verify_aud(self, payload):
+        audience = payload.get('aud')
+        if audience == FIREBASE_AUDIENCE:
+            raise self._invalid_token_error(
+                '{0} expects {1}, but was given a custom '
+                'token.'.format(self.operation, self.articled_short_name))
+        elif audience != self.project_id:
+            raise self._invalid_token_error(
+                'Firebase {0} has incorrect "aud" (audience) claim. Expected "{1}" but got "{2}". '
+                '{3} {4}'.format(self.short_name, self.project_id, audience,
+                                 self.project_id_match_msg, self.verify_id_token_msg))
+
+    def _verify_kid_and_alg(self, header, payload):
+        key_id = header.get('kid')
+        algorithm = header.get('alg')
+        if not key_id:
+            if algorithm == 'HS256' and payload.get('v') is 0 and 'uid' in payload.get('d', {}):
+                raise self._invalid_token_error(
+                    '{0} expects {1}, but was given a legacy custom '
+                    'token.'.format(self.operation, self.articled_short_name))
+            else:
+                raise self._invalid_token_error(
+                    'Firebase {0} has no "kid" claim.'.format(self.short_name))
+        elif algorithm != 'RS256':
+            raise self._invalid_token_error(
+                'Firebase {0} has incorrect algorithm. Expected "RS256" but got "{1}". '
+                '{2}'.format(self.short_name, algorithm, self.verify_id_token_msg))
+
+    def _verify_iss(self, payload):
+        issuer = payload.get('iss')
+        if issuer != self.expected_issuer:
+            raise self._invalid_token_error(
+                'Firebase {0} has incorrect "iss" (issuer) claim. Expected "{1}" but '
+                'got "{2}". {3} {4}'.format(self.short_name, self.expected_issuer, issuer,
+                                            self.project_id_match_msg, self.verify_id_token_msg))
+
+    def _verify_sub(self, payload):
+        subject = payload.get('sub')
+        if subject is None or not isinstance(subject, six.string_types):
+            raise self._invalid_token_error(
+                'Firebase {0} has no "sub" (subject) claim. '
+                '{1}'.format(self.short_name, self.verify_id_token_msg))
+        elif not subject:
+            raise self._invalid_token_error(
+                'Firebase {0} has an empty string "sub" (subject) claim. '
+                '{1}'.format(self.short_name, self.verify_id_token_msg))
+        elif len(subject) > 128:
+            raise self._invalid_token_error(
+                'Firebase {0} has a "sub" (subject) claim longer than 128 characters. '
+                '{1}'.format(self.short_name, self.verify_id_token_msg))
+
+    def _verify_iat_and_exp(self, payload):
+        if 'iat' not in payload:
+            raise self._invalid_token_error('Token does not contain required claim "iat"')
+        if 'exp' not in payload:
+            raise self._invalid_token_error('Token does not contain required claim "exp"')
+        now = calendar.timegm(datetime.datetime.utcnow().utctimetuple())
+        if now < payload['iat'] - _CLOCK_SKEW_SECS:
+            raise self._invalid_token_error(
+                'Token used too early, {0} < {1}'.format(now, payload['iat']))
+        if now > payload['exp'] + _CLOCK_SKEW_SECS:
+            raise self._expired_token_error(
+                'Token expired, {0} < {1}'.format(payload['exp'], now), cause=None)
+
+    def _verify_token_signature(self, token, request):
+        try:
+            verified_claims = google.oauth2.id_token.verify_token(
+                token, request=request, audience=self.project_id, certs_url=self.cert_url)
+            return verified_claims
+        except google.auth.exceptions.TransportError as error:
+            raise CertificateFetchError(str(error), cause=error)
+        except ValueError as error:
+            error_factory = (self._expired_token_error if 'Token expired' in str(error) else
+                             self._invalid_token_error)
+            raise error_factory(str(error), cause=error)
 
 
 class TokenSignError(exceptions.UnknownError):

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -243,7 +243,7 @@ class TokenVerifier(object):
             project_id=app.project_id, short_name='session cookie',
             operation='verify_session_cookie()',
             doc_url='https://firebase.google.com/docs/auth/admin/verify-id-tokens',
-            cert_url=_auth_utils.get_cookie_cert_url('/relyingparty'),
+            cert_url=_auth_utils.get_cookie_cert_url(),
             issuer=COOKIE_ISSUER_PREFIX,
             invalid_token_error=InvalidSessionCookieError,
             expired_token_error=ExpiredSessionCookieError)

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -35,13 +35,11 @@ from firebase_admin import _auth_utils
 
 
 # ID token constants
-ID_TOKEN_ISSUER_PREFIX = 'https://securetoken.google.com/'
 ID_TOKEN_CERT_URI = ('https://www.googleapis.com/robot/v1/metadata/x509/'
                      'securetoken@system.gserviceaccount.com')
 
 # Session cookie constants
 COOKIE_ISSUER_PREFIX = 'https://session.firebase.google.com/'
-COOKIE_CERT_URI = 'https://www.googleapis.com/identitytoolkit/v3/relyingparty/publicKeys'
 MIN_SESSION_COOKIE_DURATION_SECONDS = int(datetime.timedelta(minutes=5).total_seconds())
 MAX_SESSION_COOKIE_DURATION_SECONDS = int(datetime.timedelta(days=14).total_seconds())
 
@@ -239,14 +237,14 @@ class TokenVerifier(object):
             operation='verify_id_token()',
             doc_url='https://firebase.google.com/docs/auth/admin/verify-id-tokens',
             cert_url=ID_TOKEN_CERT_URI,
-            issuer=ID_TOKEN_ISSUER_PREFIX,
+            issuer=_auth_utils.get_token_issuer(),
             invalid_token_error=_auth_utils.InvalidIdTokenError,
             expired_token_error=ExpiredIdTokenError)
         self.cookie_verifier = _JWTVerifier(
             project_id=app.project_id, short_name='session cookie',
             operation='verify_session_cookie()',
             doc_url='https://firebase.google.com/docs/auth/admin/verify-id-tokens',
-            cert_url=COOKIE_CERT_URI,
+            cert_url=_auth_utils.get_cookie_cert_url('/relyingparty'),
             issuer=COOKIE_ISSUER_PREFIX,
             invalid_token_error=InvalidSessionCookieError,
             expired_token_error=ExpiredSessionCookieError)

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -369,9 +369,9 @@ class _JWTVerifier(object):
         except google.auth.exceptions.TransportError as error:
             raise CertificateFetchError(str(error), cause=error)
         except ValueError as error:
-            error_factory = (self._expired_token_error if 'Token expired' in str(error) else
-                             self._invalid_token_error)
-            raise error_factory(str(error), cause=error)
+            if 'Token expired' in str(error):
+                raise self._expired_token_error(str(error), cause=error)
+            raise self._invalid_token_error(str(error), cause=error)
 
     def verify(self, token, request):
         """Verifies the signature and data for the provided JWT."""

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -56,14 +56,14 @@ RESERVED_CLAIMS = set([
 METADATA_SERVICE_URL = ('http://metadata.google.internal/computeMetadata/v1/instance/'
                         'service-accounts/default/email')
 
-_CLOCK_SKEW_SECS = 10  # 10 seconds
+_CLOCK_SKEW_SECS = 10
 
 
 class _EmulatedSigner(crypt.Signer):
 
     @property
     def key_id(self):
-        return None
+        return b''
 
     def sign(self, unused_message):
         return b''

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -34,12 +34,7 @@ from firebase_admin import exceptions
 from firebase_admin import _auth_utils
 
 
-# ID token constants
-ID_TOKEN_CERT_URI = ('https://www.googleapis.com/robot/v1/metadata/x509/'
-                     'securetoken@system.gserviceaccount.com')
-
 # Session cookie constants
-COOKIE_ISSUER_PREFIX = 'https://session.firebase.google.com/'
 MIN_SESSION_COOKIE_DURATION_SECONDS = int(datetime.timedelta(minutes=5).total_seconds())
 MAX_SESSION_COOKIE_DURATION_SECONDS = int(datetime.timedelta(days=14).total_seconds())
 
@@ -236,7 +231,7 @@ class TokenVerifier(object):
             project_id=app.project_id, short_name='ID token',
             operation='verify_id_token()',
             doc_url='https://firebase.google.com/docs/auth/admin/verify-id-tokens',
-            cert_url=ID_TOKEN_CERT_URI,
+            cert_url=_auth_utils.get_token_cert_url(),
             issuer=_auth_utils.get_token_issuer(),
             invalid_token_error=_auth_utils.InvalidIdTokenError,
             expired_token_error=ExpiredIdTokenError)
@@ -245,7 +240,7 @@ class TokenVerifier(object):
             operation='verify_session_cookie()',
             doc_url='https://firebase.google.com/docs/auth/admin/verify-id-tokens',
             cert_url=_auth_utils.get_cookie_cert_url('/relyingparty'),
-            issuer=COOKIE_ISSUER_PREFIX,
+            issuer=_auth_utils.get_cookie_issuer(),
             invalid_token_error=InvalidSessionCookieError,
             expired_token_error=ExpiredSessionCookieError)
 

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -555,10 +555,8 @@ class _AuthService(object):
             2. set the project ID explicitly via Firebase App options, or
             3. set the project ID via the GOOGLE_CLOUD_PROJECT environment variable.""")
 
-        self.url_builder = _auth_utils.AuthResourceUrlBuilder(app.project_id)
-
         client = _http_client.JsonHttpClient(
-            credential=credential, base_url=self.url_builder.get_url(),
+            credential=credential, base_url=_auth_utils.get_auth_resource_url(app.project_id),
             headers={'X-Client-Version': version_header})
         self._token_generator = _token_gen.TokenGenerator(app, client)
         self._token_verifier = _token_gen.TokenVerifier(app)

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -555,10 +555,10 @@ class _AuthService(object):
             2. set the project ID explicitly via Firebase App options, or
             3. set the project ID via the GOOGLE_CLOUD_PROJECT environment variable.""")
 
-        self.auth_url_builder = _auth_utils.AuthResourceUrlBuilder(app.project_id)
+        self.url_builder = _auth_utils.AuthResourceUrlBuilder(app.project_id)
 
         client = _http_client.JsonHttpClient(
-            credential=credential, base_url=self.auth_url_builder.get_url(),
+            credential=credential, base_url=self.url_builder.get_url(),
             headers={'X-Client-Version': version_header})
         self._token_generator = _token_gen.TokenGenerator(app, client)
         self._token_verifier = _token_gen.TokenVerifier(app)

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -555,9 +555,13 @@ class _AuthService(object):
             2. set the project ID explicitly via Firebase App options, or
             3. set the project ID via the GOOGLE_CLOUD_PROJECT environment variable.""")
 
+        headers = {'X-Client-Version': version_header}
+        if _auth_utils.is_emulator_enabled():
+            headers['Authorization'] = 'Bearer owner'
+
         client = _http_client.JsonHttpClient(
             credential=credential, base_url=_auth_utils.get_auth_resource_url(app.project_id),
-            headers={'X-Client-Version': version_header})
+            headers=headers)
         self._token_generator = _token_gen.TokenGenerator(app, client)
         self._token_verifier = _token_gen.TokenVerifier(app)
         self._user_manager = _user_mgt.UserManager(client)

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -545,8 +545,6 @@ def _check_jwt_revoked(verified_claims, exc_type, label, app):
 class _AuthService(object):
     """Firebase Authentication service."""
 
-    ID_TOOLKIT_URL = 'https://identitytoolkit.googleapis.com/v1/projects/'
-
     def __init__(self, app):
         credential = app.credential.get_credential()
         version_header = 'Python/Admin/{0}'.format(firebase_admin.__version__)
@@ -557,8 +555,10 @@ class _AuthService(object):
             2. set the project ID explicitly via Firebase App options, or
             3. set the project ID via the GOOGLE_CLOUD_PROJECT environment variable.""")
 
+        self.auth_url_builder = _auth_utils.AuthResourceUrlBuilder(app.project_id)
+
         client = _http_client.JsonHttpClient(
-            credential=credential, base_url=self.ID_TOOLKIT_URL + app.project_id,
+            credential=credential, base_url=self.auth_url_builder.get_url(),
             headers={'X-Client-Version': version_header})
         self._token_generator = _token_gen.TokenGenerator(app, client)
         self._token_verifier = _token_gen.TokenVerifier(app)

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -114,7 +114,7 @@ def _instrument_user_manager(app, status, payload):
     user_manager = auth_service.user_manager
     recorder = []
     user_manager._client.session.mount(
-        auth._AuthService.ID_TOOLKIT_URL,
+        auth_service.auth_url_builder.get_url(),
         testutils.MockAdapter(payload, status, recorder))
     return user_manager, recorder
 

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -114,7 +114,7 @@ def _instrument_user_manager(app, status, payload):
     user_manager = auth_service.user_manager
     recorder = []
     user_manager._client.session.mount(
-        auth_service.auth_url_builder.get_url(),
+        auth_service.url_builder.get_url(),
         testutils.MockAdapter(payload, status, recorder))
     return user_manager, recorder
 

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -33,6 +33,7 @@ from firebase_admin import auth
 from firebase_admin import credentials
 from firebase_admin import exceptions
 from firebase_admin import _token_gen
+from firebase_admin import _auth_utils
 from tests import testutils
 
 
@@ -114,7 +115,7 @@ def _instrument_user_manager(app, status, payload):
     user_manager = auth_service.user_manager
     recorder = []
     user_manager._client.session.mount(
-        auth_service.url_builder.get_url(),
+        _auth_utils.get_auth_resource_url(app.project_id),
         testutils.MockAdapter(payload, status, recorder))
     return user_manager, recorder
 

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -62,7 +62,7 @@ def _instrument_user_manager(app, status, payload):
     user_manager = auth_service.user_manager
     recorder = []
     user_manager._client.session.mount(
-        auth_service.url_builder.get_url(),
+        _auth_utils.get_auth_resource_url(app.project_id),
         testutils.MockAdapter(payload, status, recorder))
     return user_manager, recorder
 

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -62,7 +62,7 @@ def _instrument_user_manager(app, status, payload):
     user_manager = auth_service.user_manager
     recorder = []
     user_manager._client.session.mount(
-        auth._AuthService.ID_TOOLKIT_URL,
+        auth_service.auth_url_builder.get_url(),
         testutils.MockAdapter(payload, status, recorder))
     return user_manager, recorder
 

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -62,7 +62,7 @@ def _instrument_user_manager(app, status, payload):
     user_manager = auth_service.user_manager
     recorder = []
     user_manager._client.session.mount(
-        auth_service.auth_url_builder.get_url(),
+        auth_service.url_builder.get_url(),
         testutils.MockAdapter(payload, status, recorder))
     return user_manager, recorder
 


### PR DESCRIPTION
# `tox` results
**NOTE**: Nondeterministic stuff has been normalized:
```bash
tox |
  sed -E "s/0x[[:xdigit:]]+/0xDEADBEEF/" |
  sed -E "s/PYTHONHASHSEED='[[:digit:]]+'/PYTHONHASHSEED='0'/g" |
  sed -E "s/[[:digit:]]+\.[[:digit:]]+(s| seconds)/00.00\1/g" |
  sed -E "s/^(message = b?)'.*'/\1'XXX'/g"
```

-   `v3.2.1-PATCH` branch results: http://bit.ly/2Mk22gv
-   `py2-emulator-support` branch results: http://bit.ly/3oy3idg
-   ```diff
    --- .tox/base-tox-report.txt	2021-01-30 15:06:16.000000000 -0500
    +++ .tox/head-tox-report.txt	2021-01-30 15:05:03.000000000 -0500
    @@ -126,7 +126,7 @@
     _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
     firebase_admin/auth.py:149: in create_custom_token
         return token_generator.create_custom_token(uid, developer_claims)
    -firebase_admin/_token_gen.py:169: in create_custom_token
    +firebase_admin/_token_gen.py:190: in create_custom_token
         return jwt.encode(signing_provider.signer, payload)
     .tox/py2/lib/python2.7/site-packages/google/auth/jwt.py:112: in encode
         signature = signer.sign(signing_input)
    @@ -166,7 +166,7 @@
     _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
     firebase_admin/auth.py:149: in create_custom_token
         return token_generator.create_custom_token(uid, developer_claims)
    -firebase_admin/_token_gen.py:169: in create_custom_token
    +firebase_admin/_token_gen.py:190: in create_custom_token
         return jwt.encode(signing_provider.signer, payload)
     .tox/py2/lib/python2.7/site-packages/google/auth/jwt.py:112: in encode
         signature = signer.sign(signing_input)
    @@ -317,7 +317,7 @@
     _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
     firebase_admin/auth.py:149: in create_custom_token
         return token_generator.create_custom_token(uid, developer_claims)
    -firebase_admin/_token_gen.py:169: in create_custom_token
    +firebase_admin/_token_gen.py:190: in create_custom_token
         return jwt.encode(signing_provider.signer, payload)
     .tox/py3/lib/python3.9/site-packages/google/auth/jwt.py:112: in encode
         signature = signer.sign(signing_input)
    @@ -357,7 +357,7 @@
     _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
     firebase_admin/auth.py:149: in create_custom_token
         return token_generator.create_custom_token(uid, developer_claims)
    -firebase_admin/_token_gen.py:169: in create_custom_token
    +firebase_admin/_token_gen.py:190: in create_custom_token
         return jwt.encode(signing_provider.signer, payload)
     .tox/py3/lib/python3.9/site-packages/google/auth/jwt.py:112: in encode
         signature = signer.sign(signing_input)
    @@ -414,17 +414,13 @@
       /Users/brianrodri/Repositories/firebase-admin-python/.tox/py3/lib/python3.9/site-packages/google/rpc/status_pb2.py:43: DeprecationWarning: Call to deprecated create function Descriptor(). Note: Create unlinked descriptors is going to go away. Please use get/find descriptors from generated code or query the descriptor_pool.
         _STATUS = _descriptor.Descriptor(
     
    -firebase_admin/_token_gen.py:290
    -  /Users/brianrodri/Repositories/firebase-admin-python/firebase_admin/_token_gen.py:290: SyntaxWarning: "is" with a literal. Did you mean "=="?
    -    if header.get('alg') == 'HS256' and payload.get(
    -
     -- Docs: https://docs.pytest.org/en/stable/warnings.html
     =========================== short test summary info ============================
     FAILED tests/test_db.py::TestDatabaseInitialization::test_valid_db_url[https://test.firebaseio.com]
     FAILED tests/test_db.py::TestDatabaseInitialization::test_valid_db_url[https://test.firebaseio.com/]
     FAILED tests/test_token_gen.py::TestCreateCustomToken::test_sign_with_iam - K...
     FAILED tests/test_token_gen.py::TestCreateCustomToken::test_sign_with_discovered_service_account
    -================= 4 failed, 2366 passed, 11 warnings in 00.00s =================
    +================= 4 failed, 2366 passed, 10 warnings in 00.00s =================
     ERROR: InvocationError for command /Users/brianrodri/Repositories/firebase-admin-python/.tox/py3/bin/pytest (exited with code 1)
     pypy create: /Users/brianrodri/Repositories/firebase-admin-python/.tox/pypy
     pypy installdeps: pytest, pytest-localserver
    @@ -612,7 +608,7 @@
     _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
     firebase_admin/auth.py:149: in create_custom_token
         return token_generator.create_custom_token(uid, developer_claims)
    -firebase_admin/_token_gen.py:169: in create_custom_token
    +firebase_admin/_token_gen.py:190: in create_custom_token
         return jwt.encode(signing_provider.signer, payload)
     .tox/cover/lib/python2.7/site-packages/google/auth/jwt.py:112: in encode
         signature = signer.sign(signing_input)
    @@ -652,7 +648,7 @@
     _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
     firebase_admin/auth.py:149: in create_custom_token
         return token_generator.create_custom_token(uid, developer_claims)
    -firebase_admin/_token_gen.py:169: in create_custom_token
    +firebase_admin/_token_gen.py:190: in create_custom_token
         return jwt.encode(signing_provider.signer, payload)
     .tox/cover/lib/python2.7/site-packages/google/auth/jwt.py:112: in encode
         signature = signer.sign(signing_input)
    @@ -680,12 +676,12 @@
     ----------------------------------------------------------
     firebase_admin/__about__.py                6      0   100%
     firebase_admin/__init__.py               123      2    98%
    -firebase_admin/_auth_utils.py            184      5    97%
    +firebase_admin/_auth_utils.py            207      9    96%
     firebase_admin/_http_client.py            49      1    98%
     firebase_admin/_messaging_encoder.py     357      7    98%
     firebase_admin/_messaging_utils.py       138      0   100%
     firebase_admin/_sseclient.py             116     16    86%
    -firebase_admin/_token_gen.py             203      5    98%
    +firebase_admin/_token_gen.py             240     21    91%
     firebase_admin/_user_import.py           170      0   100%
     firebase_admin/_user_mgt.py              310     11    96%
     firebase_admin/_utils.py                 101      0   100%
    @@ -714,7 +710,7 @@
     tests/test_user_mgt.py                   813      0   100%
     tests/testutils.py                        89      4    96%
     ----------------------------------------------------------
    -TOTAL                                   7558    107    99%
    +TOTAL                                   7618    127    98%
     
     ============== 4 failed, 2366 passed, 1 warnings in 00.00 seconds ==============
     ERROR: InvocationError for command /Users/brianrodri/Repositories/firebase-admin-python/.tox/cover/bin/pytest --cov=firebase_admin --cov=tests (exited with code 1)
    ```

# `./lint.sh all` results
-   ```bash
    Running linter on module firebase_admin
    Running linter on module tests
    Running linter on module integration
    Running linter on module snippets
    ```